### PR TITLE
fix: allow parcnet-pod serialization to be compatible with POD

### DIFF
--- a/chat/src/chat/loader.rs
+++ b/chat/src/chat/loader.rs
@@ -1,20 +1,20 @@
 use std::time::Duration;
 
 use gpui::{
-    black, bounce, div, ease_in_out, percentage, svg, white, Animation, AnimationExt, IntoElement,
-    Length, ParentElement, Pixels, Render, Styled, Transformation, ViewContext,
+    black, bounce, div, ease_in_out, percentage, svg, white, Animation, AnimationExt, Context,
+    IntoElement, Length, ParentElement, Pixels, Render, Styled, Transformation, Window,
 };
 
 pub struct Loader {}
 
 impl Loader {
-    pub fn new(_cx: &mut ViewContext<Self>) -> Self {
+    pub fn new(_cx: &mut Context<Self>) -> Self {
         Loader {}
     }
 }
 
 impl Render for Loader {
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
         div().flex().flex_col().size_full().justify_around().child(
             div().flex().flex_row().w_full().justify_around().child(
                 div()

--- a/chat/src/chat/name.rs
+++ b/chat/src/chat/name.rs
@@ -1,4 +1,4 @@
-use gpui::{div, rgba, IntoElement, ParentElement, Render, Styled, ViewContext};
+use gpui::{div, rgba, Context, IntoElement, ParentElement, Render, Styled, Window};
 use iroh::net::key::PublicKey;
 use std::sync::Arc;
 
@@ -10,13 +10,13 @@ pub struct Name {
 }
 
 impl Name {
-    pub fn new(_cx: &mut ViewContext<Self>, pubkey: PublicKey, logic: Arc<Logic>) -> Self {
+    pub fn new(_cx: &mut Context<Self>, pubkey: PublicKey, logic: Arc<Logic>) -> Self {
         Name { pubkey, logic }
     }
 }
 
 impl Render for Name {
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
         let name = self.logic.get_name(&self.pubkey);
         div().text_color(rgba(0x00000050)).child(name)
     }

--- a/chat/src/chat/podcount.rs
+++ b/chat/src/chat/podcount.rs
@@ -1,4 +1,4 @@
-use gpui::{div, IntoElement, ParentElement, Render, ViewContext};
+use gpui::{div, Context, IntoElement, ParentElement, Render, Window};
 use std::sync::Arc;
 
 use crate::logic::Logic;
@@ -8,9 +8,9 @@ pub struct Podcount {
 }
 
 impl Podcount {
-    pub fn new(cx: &mut ViewContext<Self>, logic: Arc<Logic>) -> Self {
+    pub fn new(cx: &mut Context<Self>, logic: Arc<Logic>) -> Self {
         let mut pod_watch = logic.get_pod_watch();
-        cx.spawn(|view, mut cx| async move {
+        cx.spawn(|view, cx| async move {
             while pod_watch.changed().await.is_ok() {
                 let _ = cx.update(|cx| {
                     view.update(cx, |_, cx| {
@@ -25,7 +25,7 @@ impl Podcount {
 }
 
 impl Render for Podcount {
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
         let podcount = self.logic.get_num_pods();
         div().child(format!("{} pods", podcount)).into_element()
     }

--- a/chat/src/main.rs
+++ b/chat/src/main.rs
@@ -3,7 +3,7 @@ mod logic;
 
 use chat::Chat;
 use gpui::{
-    actions, point, px, size, App, AppContext, Bounds, KeyBinding, TitlebarOptions, VisualContext,
+    actions, point, px, size, App, AppContext, Application, Bounds, KeyBinding, TitlebarOptions,
     WindowBounds, WindowOptions,
 };
 use logic::{get_app_path, is_dev};
@@ -28,9 +28,9 @@ async fn main() {
         .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
         .init();
 
-    App::new()
+    Application::new()
         .with_assets(assets::Assets {})
-        .run(|cx: &mut AppContext| {
+        .run(|cx: &mut App| {
             cx.activate(true);
             cx.on_action(quit);
             cx.bind_keys([KeyBinding::new("cmd-q", Quit, None)]);
@@ -47,11 +47,11 @@ async fn main() {
                     }),
                     ..Default::default()
                 },
-                |cx| cx.new_view(Chat::new),
+                |_, cx| cx.new(Chat::new),
             );
         })
 }
 
-fn quit(_: &Quit, cx: &mut gpui::AppContext) {
+fn quit(_: &Quit, cx: &mut gpui::App) {
     cx.quit();
 }

--- a/parcnet-pod/src/pod/mod.rs
+++ b/parcnet-pod/src/pod/mod.rs
@@ -15,7 +15,6 @@ use thiserror::Error;
 
 use serde::{Deserialize, Serialize};
 
-use uuid::Uuid;
 pub use value::PodValue;
 
 use crate::crypto::lean_imt::lean_poseidon_imt;
@@ -25,31 +24,19 @@ pub(crate) type Error = Box<dyn std::error::Error>;
 pub type PodEntries = IndexMap<String, PodValue>;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct PodClaim {
+pub struct Pod {
     entries: PodEntries,
     #[serde(
         serialize_with = "compressed_pt_ser",
         deserialize_with = "compressed_pt_de"
     )]
     signer_public_key: Point,
-}
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct PodProof {
     #[serde(
         serialize_with = "compressed_sig_ser",
         deserialize_with = "compressed_sig_de"
     )]
     signature: Signature,
-}
-
-// TODO: Store content ID and skip it in serialisation.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct Pod {
-    id: Uuid,
-    claim: PodClaim,
-    proof: PodProof,
 }
 
 impl Pod {
@@ -83,26 +70,22 @@ impl Pod {
             .map_err(|_| PodCreationError::SignatureError)?;
 
         Ok(Pod {
-            id: Uuid::new_v4(),
-            claim: PodClaim {
-                entries,
-                signer_public_key,
-            },
-            proof: PodProof { signature },
+            entries,
+            signer_public_key,
+            signature,
         })
     }
 
     pub fn entries(&self) -> PodEntries {
-        self.claim.entries.clone()
+        self.entries.clone()
     }
 
     pub fn get(&self, key: &str) -> Option<&PodValue> {
-        self.claim.entries.get(key)
+        self.entries.get(key)
     }
 
     pub fn content_id(&self) -> Result<Fq, PodCreationError> {
         let hashes = self
-            .claim
             .entries
             .par_iter()
             .flat_map(|(k, v)| [PodValue::String(k.to_string()).hash(), v.hash()])
@@ -111,11 +94,11 @@ impl Pod {
     }
 
     pub fn signer_public_key(&self) -> Point {
-        self.claim.signer_public_key.clone()
+        self.signer_public_key.clone()
     }
 
     pub fn signature(&self) -> Signature {
-        self.proof.signature.clone()
+        self.signature.clone()
     }
 
     pub fn verify(&self) -> Result<bool, Error> {
@@ -170,12 +153,9 @@ where
         .map_err(|_| PodCreationError::SignatureError)?;
 
     Ok(Pod {
-        id: Uuid::new_v4(),
-        claim: PodClaim {
-            entries,
-            signer_public_key,
-        },
-        proof: PodProof { signature },
+        entries,
+        signer_public_key,
+        signature,
     })
 }
 
@@ -266,7 +246,7 @@ mod tests {
     #[test]
     fn test_pod_creation() -> Result<(), PodCreationError> {
         let pod = create_test_pod()?;
-        assert_eq!(pod.claim.entries.len(), 12);
+        assert_eq!(pod.entries.len(), 12);
         assert_eq!(pod.get("G"), Some(&PodValue::Int(7)));
         assert_eq!(pod.get("F"), Some(&PodValue::Cryptographic(Fq::from(-1))));
 

--- a/parcnet-pod/src/pod/mod.rs
+++ b/parcnet-pod/src/pod/mod.rs
@@ -23,7 +23,7 @@ pub(crate) type Error = Box<dyn std::error::Error>;
 
 pub type PodEntries = IndexMap<String, PodValue>;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Pod {
     entries: PodEntries,
     #[serde(

--- a/parcnet-pod/src/pod/zupass.rs
+++ b/parcnet-pod/src/pod/zupass.rs
@@ -35,6 +35,30 @@ pub struct PodPcd {
     proof: PodPcdProof,
 }
 
+impl Into<PodPcd> for Pod {
+    fn into(self) -> PodPcd {
+        let id = Uuid::new_v4();
+        let claim = PodPcdClaim {
+            entries: self.entries,
+            signer_public_key: self.signer_public_key,
+        };
+        let proof = PodPcdProof {
+            signature: self.signature,
+        };
+        PodPcd { id, claim, proof }
+    }
+}
+
+impl Into<Pod> for PodPcd {
+    fn into(self) -> Pod {
+        Pod {
+            entries: self.claim.entries,
+            signer_public_key: self.claim.signer_public_key,
+            signature: self.proof.signature,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 struct ZupassPcdWrapper {
     #[serde(rename = "type")]


### PR DESCRIPTION
Updates `parcnet-pod` library to emit and serialize [PODs](https://pod.org). Previously, the Pod struct and its associated default `serde` serialization was not compatible with any POD produced by the TypeScript or Go libraries.

Note that this is not the canonical / most up-to-date format, which is even more concise (e.g., serializes and deserializes strings directly rather than `{ "string": "exampleString" }`.