### PR TITLE
feat(pod2): use content IDs for origin IDs

### DIFF
--- a/pod2/src/plonky2_u32/gadgets/arithmetic_u32.rs
+++ b/pod2/src/plonky2_u32/gadgets/arithmetic_u32.rs
@@ -19,10 +19,7 @@ use crate::plonky2_u32::gates::subtraction_u32::U32SubtractionGate;
 use crate::plonky2_u32::serialization::{ReadU32, WriteU32};
 use crate::plonky2_u32::witness::GeneratedValuesU32;
 use crate::signature::biguint::{
-    BigUintTarget, 
-    CircuitBuilderBiguint, 
-    GeneratedValuesBigUint,
-    WitnessBigUint
+    BigUintTarget, CircuitBuilderBiguint, GeneratedValuesBigUint, WitnessBigUint,
 };
 
 #[derive(Clone, Copy, Debug)]

--- a/pod2/src/pod/circuit/operation.rs
+++ b/pod2/src/pod/circuit/operation.rs
@@ -183,8 +183,11 @@ impl<const VL: usize> OperationTarget<VL> {
         };
         // TODO: Proper origin check
         let statements_allow_transitivity = {
-            let origins_match = target_slice_eq(builder, &statement1_target.origin2.origin_id,
-                &statement2_target.origin1.origin_id);
+            let origins_match = target_slice_eq(
+                builder,
+                &statement1_target.origin2.origin_id,
+                &statement2_target.origin1.origin_id,
+            );
             let keys_match = builder.is_equal(statement1_target.key2, statement2_target.key1);
             builder.and(origins_match, keys_match)
         };
@@ -221,7 +224,8 @@ impl<const VL: usize> OperationTarget<VL> {
                     statement2_target.has_code(builder, Statement::EQUAL),
                     // Anchored key equality. TODO.
                     builder.is_equal(statement1_target.key1, statement2_target.key1),
-                    target_slice_eq(builder,
+                    target_slice_eq(
+                        builder,
                         &statement1_target.origin1.origin_id,
                         &statement2_target.origin1.origin_id,
                     ),

--- a/pod2/src/pod/circuit/operation.rs
+++ b/pod2/src/pod/circuit/operation.rs
@@ -26,7 +26,7 @@ use super::{
     entry::EntryTarget,
     origin::OriginTarget,
     statement::{StatementRefTarget, StatementTarget},
-    util::{and, assert_less_if, member},
+    util::{and, assert_less_if, member, target_slice_eq},
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -183,10 +183,8 @@ impl<const VL: usize> OperationTarget<VL> {
         };
         // TODO: Proper origin check
         let statements_allow_transitivity = {
-            let origins_match = builder.is_equal(
-                statement1_target.origin2.origin_id,
-                statement2_target.origin1.origin_id,
-            );
+            let origins_match = target_slice_eq(builder, &statement1_target.origin2.origin_id,
+                &statement2_target.origin1.origin_id);
             let keys_match = builder.is_equal(statement1_target.key2, statement2_target.key1);
             builder.and(origins_match, keys_match)
         };
@@ -223,9 +221,9 @@ impl<const VL: usize> OperationTarget<VL> {
                     statement2_target.has_code(builder, Statement::EQUAL),
                     // Anchored key equality. TODO.
                     builder.is_equal(statement1_target.key1, statement2_target.key1),
-                    builder.is_equal(
-                        statement1_target.origin1.origin_id,
-                        statement2_target.origin1.origin_id,
+                    target_slice_eq(builder,
+                        &statement1_target.origin1.origin_id,
+                        &statement2_target.origin1.origin_id,
                     ),
                 ];
                 and(builder, conditions)

--- a/pod2/src/pod/circuit/origin.rs
+++ b/pod2/src/pod/circuit/origin.rs
@@ -1,45 +1,47 @@
+use std::array;
+
 use anyhow::Result;
 use plonky2::{
     field::{goldilocks_field::GoldilocksField, types::Field},
     iop::{
-        target::Target,
+        target::{BoolTarget, Target},
         witness::{PartialWitness, WitnessWrite},
     },
     plonk::circuit_builder::CircuitBuilder,
 };
 
-use super::util::matrix_ref;
-use crate::pod::{gadget::GadgetID, origin::Origin};
+use super::util::{matrix_ref, target_slice_eq};
+use crate::pod::{gadget::GadgetID, origin::{Origin, ORIGIN_ID_SELF}};
 use crate::{D, F};
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct OriginTarget {
-    pub origin_id: Target,
+    pub origin_id: [Target; 4],
     pub gadget_id: Target,
 }
 
 impl OriginTarget {
     pub fn new_virtual(builder: &mut CircuitBuilder<F, D>) -> Self {
         Self {
-            origin_id: builder.add_virtual_target(),
+            origin_id: builder.add_virtual_target_arr(),
             gadget_id: builder.add_virtual_target(),
         }
     }
     pub fn register_as_public_input(&self, builder: &mut CircuitBuilder<F, D>) {
-        builder.register_public_input(self.origin_id);
+        builder.register_public_inputs(&self.origin_id);
         builder.register_public_input(self.gadget_id);
     }
     pub fn to_targets(&self) -> Vec<Target> {
-        vec![self.origin_id, self.gadget_id]
+        [self.origin_id.to_vec(), vec![self.gadget_id]].concat()
     }
     pub fn from_targets(v: &[Target]) -> Self {
         Self {
-            origin_id: v[0],
-            gadget_id: v[1],
+            origin_id: array::from_fn(|i| v[i]),
+            gadget_id: v[4],
         }
     }
     pub fn set_witness(&self, pw: &mut PartialWitness<F>, origin: &Origin) -> Result<()> {
-        pw.set_target(self.origin_id, origin.origin_id)?;
+        pw.set_target_arr(&self.origin_id, &origin.origin_id)?;
         pw.set_target(
             self.gadget_id,
             F::from_canonical_u64(origin.gadget_id as usize as u64),
@@ -48,26 +50,18 @@ impl OriginTarget {
     }
     pub fn none(builder: &mut CircuitBuilder<F, D>) -> Self {
         Self {
-            origin_id: builder.zero(),
+            origin_id: [builder.zero(); 4],
             gadget_id: builder.zero(),
         }
     }
     pub fn auto(builder: &mut CircuitBuilder<F, D>, gadget_id: GadgetID) -> Self {
         Self {
-            origin_id: builder.constant(Origin::SELF.origin_id),
+            origin_id: array::from_fn(|i| builder.constant(ORIGIN_ID_SELF[i])),
             gadget_id: builder.constant(GoldilocksField(gadget_id as u64)),
         }
     }
-
-    pub fn remap(
-        &self,
-        builder: &mut CircuitBuilder<F, D>,
-        origin_id_map: &[Vec<Target>],
-        pod_index: Target,
-    ) -> Result<Self> {
-        Ok(Self {
-            origin_id: matrix_ref(builder, origin_id_map, pod_index, self.origin_id)?,
-            gadget_id: self.gadget_id,
-        })
+    pub fn is_self(&self, builder: &mut CircuitBuilder<F, D>) -> BoolTarget {
+        let self_origin_id: [Target; 4] = array::from_fn(|i| builder.constant(ORIGIN_ID_SELF[i]));
+        target_slice_eq(builder, &self.origin_id, &self_origin_id)
     }
 }

--- a/pod2/src/pod/circuit/origin.rs
+++ b/pod2/src/pod/circuit/origin.rs
@@ -11,7 +11,10 @@ use plonky2::{
 };
 
 use super::util::{matrix_ref, target_slice_eq};
-use crate::pod::{gadget::GadgetID, origin::{Origin, ORIGIN_ID_SELF}};
+use crate::pod::{
+    gadget::GadgetID,
+    origin::{Origin, ORIGIN_ID_SELF},
+};
 use crate::{D, F};
 
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/pod2/src/pod/circuit/pod.rs
+++ b/pod2/src/pod/circuit/pod.rs
@@ -52,16 +52,17 @@ impl SchnorrPODTarget {
                 .as_ref(),
             self.pk_index,
         )?;
-        let origin_id_target = array::try_from_fn(|i|
+        let origin_id_target = array::try_from_fn(|i| {
             vector_ref(
-            builder,
-            self.payload
-                .iter()
-                .map(|s| s.origin1.origin_id[i])
-                .collect::<Vec<_>>()
-                .as_ref(),
-            self.pk_index,
-        ))?;
+                builder,
+                self.payload
+                    .iter()
+                    .map(|s| s.origin1.origin_id[i])
+                    .collect::<Vec<_>>()
+                    .as_ref(),
+                self.pk_index,
+            )
+        })?;
         let value_target = vector_ref(
             builder,
             self.payload
@@ -76,7 +77,8 @@ impl SchnorrPODTarget {
         builder.connect(key_target, expected_pk_entry_key);
 
         // Check origin ID, which should be 1 for self.
-        let self_origin_id_target = OriginTarget::auto(builder, crate::pod::gadget::GadgetID::SCHNORR16).origin_id;
+        let self_origin_id_target =
+            OriginTarget::auto(builder, crate::pod::gadget::GadgetID::SCHNORR16).origin_id;
         builder.connect_array(self_origin_id_target, origin_id_target);
 
         // This suggests we are OK.

--- a/pod2/src/pod/circuit/statement.rs
+++ b/pod2/src/pod/circuit/statement.rs
@@ -1,11 +1,11 @@
+use std::array;
+
 use anyhow::Result;
 use plonky2::{
-    field::{goldilocks_field::GoldilocksField, types::Field},
-    iop::{
+    field::{goldilocks_field::GoldilocksField, types::Field}, hash::hash_types::HashOutTarget, iop::{
         target::{BoolTarget, Target},
         witness::{PartialWitness, WitnessWrite},
-    },
-    plonk::circuit_builder::CircuitBuilder,
+    }, plonk::circuit_builder::CircuitBuilder
 };
 
 use crate::pod::{
@@ -336,16 +336,25 @@ impl StatementTarget {
     pub fn remap_origins(
         self,
         builder: &mut CircuitBuilder<F, D>,
-        origin_id_map: &[Vec<Target>],
-        pod_index: Target,
+        content_id_target: HashOutTarget
     ) -> Result<Self> {
+        let remapped_origin = [self.origin1, self.origin2, self.origin2].iter().map(
+            |o| {
+                let origin_is_self = o.is_self(builder);
+                OriginTarget {
+                    origin_id:  array::from_fn(|i| builder.select(origin_is_self, content_id_target.elements[i], o.origin_id[i])),
+                    gadget_id: o.gadget_id
+                }
+            }
+            ).collect::<Vec<_>>();
+        
         Ok(Self {
             predicate: self.predicate,
-            origin1: self.origin1.remap(builder, origin_id_map, pod_index)?,
+            origin1: remapped_origin[0],
             key1: self.key1,
-            origin2: self.origin2.remap(builder, origin_id_map, pod_index)?,
+            origin2: remapped_origin[1],
             key2: self.key2,
-            origin3: self.origin3.remap(builder, origin_id_map, pod_index)?,
+            origin3: remapped_origin[2],
             key3: self.key3,
             value: self.value,
         })

--- a/pod2/src/pod/circuit/util.rs
+++ b/pod2/src/pod/circuit/util.rs
@@ -91,13 +91,13 @@ pub fn statement_matrix_ref(
     i: Target,
     j: Target,
 ) -> Result<StatementTarget> {
-    // Separate the statement matrix into a vector (of length 11) of
+    // Separate the statement matrix into a vector (of length 20) of
     // matrices of targets.
     let transposed_target_matrices = statement_matrix
         .iter()
         .map(|s_vec| s_vec.iter().map(|s| s.to_targets()).collect())
         .collect::<Vec<Vec<Vec<Target>>>>();
-    let target_matrices: Vec<Vec<Vec<Target>>> = (0..11)
+    let target_matrices: Vec<Vec<Vec<Target>>> = (0..20)
         .map(|i| {
             transposed_target_matrices
                 .iter()
@@ -155,13 +155,13 @@ pub fn and(builder: &mut CircuitBuilder<F, D>, v: &[BoolTarget]) -> BoolTarget {
         .fold(builder._true(), |acc, ind| builder.and(acc, *ind))
 }
 
-pub fn target_slice_eq(builder: &mut CircuitBuilder<F, D>, v: &[Target], w: &[Target]) -> BoolTarget {
-    zip(v,
-        w
-            ).fold(builder._true(),
-                   |b,(x,y)| {
-                       let eq_check = builder.is_equal(*x,*y);
-                       builder.and(b, eq_check)
-                       
-                   })
+pub fn target_slice_eq(
+    builder: &mut CircuitBuilder<F, D>,
+    v: &[Target],
+    w: &[Target],
+) -> BoolTarget {
+    zip(v, w).fold(builder._true(), |b, (x, y)| {
+        let eq_check = builder.is_equal(*x, *y);
+        builder.and(b, eq_check)
+    })
 }

--- a/pod2/src/pod/circuit/util.rs
+++ b/pod2/src/pod/circuit/util.rs
@@ -5,6 +5,7 @@ use plonky2::{
     plonk::circuit_builder::CircuitBuilder,
     // util::log2_ceil,
 };
+use std::iter::zip;
 
 use super::statement::StatementTarget;
 use crate::{D, F};
@@ -152,4 +153,15 @@ pub fn member(builder: &mut CircuitBuilder<F, D>, x: Target, v: &[Target]) -> Bo
 pub fn and(builder: &mut CircuitBuilder<F, D>, v: &[BoolTarget]) -> BoolTarget {
     v.iter()
         .fold(builder._true(), |acc, ind| builder.and(acc, *ind))
+}
+
+pub fn target_slice_eq(builder: &mut CircuitBuilder<F, D>, v: &[Target], w: &[Target]) -> BoolTarget {
+    zip(v,
+        w
+            ).fold(builder._true(),
+                   |b,(x,y)| {
+                       let eq_check = builder.is_equal(*x,*y);
+                       builder.and(b, eq_check)
+                       
+                   })
 }

--- a/pod2/src/pod/gadget/opexecutor.rs
+++ b/pod2/src/pod/gadget/opexecutor.rs
@@ -1,16 +1,20 @@
 use anyhow::Result;
 use plonky2::{
-    field::goldilocks_field::GoldilocksField, hash::hash_types::{HashOut, HashOutTarget}, iop::{
+    field::goldilocks_field::GoldilocksField,
+    hash::hash_types::{HashOut, HashOutTarget},
+    iop::{
         target::Target,
         witness::{PartialWitness, WitnessWrite},
-    }, plonk::circuit_builder::CircuitBuilder
+    },
+    plonk::circuit_builder::CircuitBuilder,
 };
 use std::array;
 use std::iter::zip;
 
 use crate::{
     pod::{
-        circuit::operation::OpListTarget, gadget::GadgetID, operation::OpList, payload::StatementList, ContentID, GPGInput
+        circuit::operation::OpListTarget, gadget::GadgetID, operation::OpList,
+        payload::StatementList, ContentID, GPGInput,
     },
     recursion::OpsExecutorTrait,
     D, F,
@@ -57,7 +61,8 @@ impl<const NP: usize, const NS: usize, const VL: usize> OpsExecutorTrait
     );
 
     fn add_targets(builder: &mut CircuitBuilder<F, D>) -> Result<Self::Targets> {
-        let content_id_list_target: [HashOutTarget; NP] = array::from_fn(|_| builder.add_virtual_hash());
+        let content_id_list_target: [HashOutTarget; NP] =
+            array::from_fn(|_| builder.add_virtual_hash());
         let statement_list_vec_target: [[StatementTarget; NS]; NP] = array::from_fn(|_| {
             array::from_fn::<StatementTarget, NS, _>(|_| StatementTarget::new_virtual(builder))
         });
@@ -65,8 +70,6 @@ impl<const NP: usize, const NS: usize, const VL: usize> OpsExecutorTrait
             array::from_fn(|_| builder.add_virtual_targets(NS + 2));
 
         let op_list_target = OpListTarget::new_virtual(builder);
-
-        // TODO: Check that origin ID map has appropriate properties.
 
         // To apply ops, remap statements' origin IDs.
         let remapped_statement_list_vec_target = statement_list_vec_target
@@ -82,7 +85,6 @@ impl<const NP: usize, const NS: usize, const VL: usize> OpsExecutorTrait
                     .collect::<Result<Vec<_>>>()
             })
             .collect::<Result<Vec<_>>>()?;
-
         // Apply ops.
         // Create output statement list target.
         let output_statement_list_target: [StatementTarget; NS] =
@@ -133,10 +135,13 @@ impl<const NP: usize, const NS: usize, const VL: usize> OpsExecutorTrait
         output: &Self::Output,
     ) -> Result<Vec<F>> {
         // Set POD targets.
-        targets.0.iter().enumerate().try_for_each(
-            |(i, hash_targ)|
-            pw.set_hash_target(*hash_targ,input.0.pods_list[i].1.content_id().into())
-            )?;
+        targets
+            .0
+            .iter()
+            .enumerate()
+            .try_for_each(|(i, hash_targ)| {
+                pw.set_hash_target(*hash_targ, input.0.pods_list[i].1.content_id().into())
+            })?;
         // TODO: Connect these to the POD targets that go into the inner and recursion circuits instead!
         zip(&targets.1, &input.0.pods_list).try_for_each(|(s_targets, (_, pod))| {
             let pod_statements = &pod.payload.statements_list;

--- a/pod2/src/pod/gadget/plonky_pod.rs
+++ b/pod2/src/pod/gadget/plonky_pod.rs
@@ -165,7 +165,6 @@ where
         prover_params: &mut ProverParams<L, M, N, NS, VL>,
         input_pods: &[(String, POD)],
         op_list: OpList,
-        origin_renaming_map: HashMap<(String, String), String>,
     ) -> Result<POD> {
         let start_execute = Instant::now();
         // Check that the input data is valid, i.e. that we have at most M
@@ -221,17 +220,17 @@ where
 
         // TODO: Constructor
         let dummy_payload = PODPayload {
-                statements_list: (0..NS)
-                    .map(|i| (format!("Dummy statement {}", i), Statement::None))
-                    .collect(),
-                statements_map: std::collections::HashMap::new(),
+            statements_list: (0..NS)
+                .map(|i| (format!("Dummy statement {}", i), Statement::None))
+                .collect(),
+            statements_map: std::collections::HashMap::new(),
         };
         let content_id = dummy_payload.hash_payload().elements;
         let dummy_plonky_pod = POD {
             payload: dummy_payload,
             proof: crate::pod::PODProof::Plonky(prover_params.dummy_proof.clone()),
             proof_type: GadgetID::PLONKY,
-            content_id
+            content_id,
         };
 
         // Note: One statement is reserved for the signer's public key.
@@ -286,7 +285,7 @@ where
         let gpg_input = {
             let sorted_gpg_input = GPGInput::new(
                 padded_pod_list.clone().into_iter().collect(),
-                origin_renaming_map,
+                HashMap::new(),
             );
             GPGInput {
                 // TODO NOTE: this feels redundant usage of `GPGInput`, first we call
@@ -314,7 +313,7 @@ where
         // TODO add prepare also the L POD1introducer PODs
         let pod1_proofs: [PlonkyProof; L] =
             array::from_fn(|k| prover_params.pod1_dummy_proof.clone());
-        let pod1_public_inputs: [Vec<F>; L] = array::from_fn(|k| vec![]);
+        let pod1_public_inputs: [Vec<F>; L] = array::from_fn(|_| vec![]);
 
         let inner_circuit_input: [POD; M] = array::from_fn(|i| schnorr_pods_padded[i].1.clone());
 
@@ -375,8 +374,8 @@ where
         // );
 
         let payload = PODPayload {
-                statements_list: output_statements.clone(),
-                statements_map: output_statements.into_iter().collect(),
+            statements_list: output_statements.clone(),
+            statements_map: output_statements.into_iter().collect(),
         };
         let content_id = payload.hash_payload().elements;
 
@@ -384,7 +383,7 @@ where
             payload,
             proof: PODProof::Plonky(plonky_proof.proof),
             proof_type: GadgetID::PLONKY,
-            content_id
+            content_id,
         })
     }
 
@@ -551,7 +550,6 @@ mod tests {
             &mut prover_params,
             &pods_list,
             op_list,
-            HashMap::new(),
         )?;
         println!("PlonkyButNotPlonkyGadget::execute(): {:?}", start.elapsed());
 
@@ -623,7 +621,6 @@ mod tests {
             &mut prover_params,
             &pods_list,
             op_list,
-            HashMap::new(),
         )?;
 
         Ok(())

--- a/pod2/src/pod/mod.rs
+++ b/pod2/src/pod/mod.rs
@@ -1,5 +1,10 @@
 use anyhow::anyhow;
 use anyhow::Result;
+use origin::OriginID;
+use origin::ORIGIN_ID_NONE;
+use origin::ORIGIN_ID_SELF;
+use origin::ORIGIN_NAME_NONE;
+use origin::ORIGIN_NAME_SELF;
 use parcnet_pod::pod::{Pod, PodValue};
 use plonky2::field::goldilocks_field::GoldilocksField;
 use plonky2::field::types::Field;
@@ -8,6 +13,7 @@ use serde::Serialize;
 
 use plonky2::field::types::PrimeField64;
 use std::collections::HashMap;
+use std::collections::HashSet;
 
 use crate::pod::gadget::{IntroducerCircuit, PlonkyButNotPlonkyGadget};
 use crate::pod::{
@@ -53,9 +59,17 @@ pub struct POD {
     pub payload: PODPayload,
     pub proof: PODProof,
     pub proof_type: GadgetID,
+    // Content ID cached here.
+    content_id: ContentID
 }
 
+pub type ContentID = [GoldilocksField; 4];
+
 impl POD {
+    pub fn content_id(&self) -> ContentID {
+        self.content_id
+    }
+    
     /// L: number of POD1-Introducer PODs
     /// M: number of PODs
     /// N: number of Plonky PODs
@@ -175,6 +189,7 @@ impl POD {
             payload,
             proof: PODProof::Schnorr(proof),
             proof_type: GadgetID::SCHNORR16,
+            content_id: payload_hash.elements
         })
     }
 
@@ -240,6 +255,7 @@ impl POD {
             payload: out_payload,
             proof: PODProof::Oracle(proof),
             proof_type: GadgetID::ORACLE,
+            content_id: payload_hash.elements
         })
     }
     // the prover_params is passed as parameter, because compunting it depends on first computing
@@ -295,8 +311,11 @@ pub struct GPGInput {
     /// ORDERED list of pods, ordered by names
     pub pods_list: Vec<(String, POD)>,
 
-    /// map from (pod name, old origin name) to new origin name
-    pub origin_renaming_map: HashMap<(String, String), String>,
+    /// map from (pod name, old origin name) to new origin name and
+    /// origin ID. Note that the origin ID will either remain the same
+    /// or be replaced with the content ID of the origin POD in the case
+    /// of a self-origin.
+    pub origin_renaming_map: HashMap<(String, String), (String, OriginID)>,
 }
 
 impl GPGInput {
@@ -304,109 +323,38 @@ impl GPGInput {
         named_pods: HashMap<String, POD>,
         origin_renaming_map: HashMap<(String, String), String>,
     ) -> Self {
-        let mut pods_and_names_list = Vec::new();
-        let mut origin_renaming_map_clone = origin_renaming_map.clone();
-        for (name, pod) in named_pods.iter() {
-            pods_and_names_list.push((name.clone(), pod.clone()));
-            origin_renaming_map_clone.insert((name.clone(), "_SELF".to_string()), name.clone());
-        }
-        pods_and_names_list.sort_by(|a, b| a.0.cmp(&b.0));
+        // Sort PODs in alphabetical order of name.
+        let mut sorted_named_pods = named_pods.clone().into_iter().collect::<Vec<_>>();
+        sorted_named_pods.sort_by(|a, b| a.0.cmp(&b.0));
+        
+        // Compile origin renaming map by mapping "_SELF" to the name
+        // of the containig POD and adopting the supplied remapping
+        // (if any) or else mapping origin O in POD P to P ++ ":" ++
+        // O.
+        let pod_origin_triples = named_pods.iter().flat_map(|(pod_name, pod)| pod.payload.statements_list.iter().flat_map(
+            |(_,statement)| statement.anchored_keys().iter().map(
+                |anchkey| (pod_name.clone(),anchkey.0.origin_name.clone(), anchkey.0.origin_id)
+                ).collect::<Vec<_>>()
+        )).collect::<HashSet<_>>();
 
+        let complete_origin_renaming_map = pod_origin_triples.into_iter().map(|(pod, old_origin_name, old_origin_id)|
+                                                            if old_origin_name == ORIGIN_NAME_SELF {
+                                                                ((pod.clone(), old_origin_name), (pod.clone(),
+                                                                                             named_pods.get(&pod).unwrap().content_id()
+                                                                ))
+                                                            } else {
+                                                                ((pod.clone(), old_origin_name.clone()),
+                                                                 (origin_renaming_map.get(&(pod.clone(), old_origin_name.clone())).map(|s| s.to_string()).unwrap_or(format!("{}:{}", pod, old_origin_name)), old_origin_id
+                                                                  
+                                                                 )
+                                                                 )
+                                                            }
+            ).collect::<HashMap<_,_>>();
+        
         Self {
-            pods_list: pods_and_names_list,
-            origin_renaming_map: origin_renaming_map_clone,
+            pods_list: sorted_named_pods,
+            origin_renaming_map: complete_origin_renaming_map,
         }
-    }
-    /// New origin name -> new origin ID map
-    fn origin_name_to_new_id_map(&self) -> HashMap<&String, usize> {
-        // Sorted new origin name list
-        let mut new_origin_name_list = self.origin_renaming_map.values().collect::<Vec<_>>();
-        new_origin_name_list.sort();
-
-        new_origin_name_list
-            .iter()
-            .enumerate()
-            .map(
-                |(idx, new_name)| (*new_name, idx + 2), // 0 reserved for none, 1 reserved for _SELF
-            )
-            .collect::<HashMap<_, _>>()
-    }
-
-    /// Maps a pair of indices consisting of POD index and origin ID to new origin ID
-    fn origin_id_map(&self) -> Result<HashMap<(usize, usize), usize>> {
-        let new_origin_name_to_id_map = self.origin_name_to_new_id_map();
-        self.origin_renaming_map
-            .keys()
-            .map(|(pod_name, origin_name)| {
-                let pod_index = self
-                    .pods_list
-                    .iter()
-                    .position(|(name, _)| name == pod_name)
-                    .ok_or(anyhow!("Error: POD {} missing from list!", pod_name))?;
-                let (_, pod) = &self.pods_list[pod_index];
-                let origin_id = if origin_name == "NONE" {
-                    GoldilocksField(0)
-                } else if origin_name == "_SELF" {
-                    GoldilocksField(1)
-                } else {
-                    pod.payload
-                        .statements_list
-                        .iter()
-                        .flat_map(|(_, s)| {
-                            s.anchored_keys()
-                                .iter()
-                                .map(|anchkey| anchkey.clone().0)
-                                .collect::<Vec<_>>()
-                        })
-                        .find(|o| &o.origin_name == origin_name)
-                        .ok_or(anyhow!(
-                            "Origin {} missing from the list of statements of POD '{}'!",
-                            origin_name,
-                            pod_name
-                        ))?
-                        .origin_id
-                };
-                Ok((
-                    (pod_index, origin_id.to_canonical_u64() as usize),
-                    *new_origin_name_to_id_map
-                        .get(
-                            self.origin_renaming_map
-                                .get(&(pod_name.clone(), origin_name.clone()))
-                                .ok_or(anyhow!(
-                                    "Missing pair {:?} in origin renaming map!",
-                                    (pod_name, origin_name)
-                                ))?,
-                        )
-                        .ok_or(anyhow!("Invalid new origin name to ID map!"))?,
-                ))
-            })
-            .collect::<Result<HashMap<(usize, usize), usize>>>()
-    }
-
-    // TODO
-    /// (POD index, old origin ID) -> new origin ID mapping as a
-    /// num_pods x (num_statements + 2) matrix.
-    fn origin_id_map_fields(&self) -> Result<Vec<Vec<GoldilocksField>>> {
-        let origin_id_map = self.origin_id_map()?;
-        let num_pods = self.pods_list.len();
-        let num_statements = self
-            .pods_list
-            .iter()
-            .map(|(_, p)| p.payload.statements_list.len())
-            .max()
-            .ok_or(anyhow!("POD with empty statement list encountered!"))?;
-        Ok((0..num_pods)
-            .map(|i| {
-                (0..(num_statements + 2))
-                    .map(|j| {
-                        origin_id_map
-                            .get(&(i, j))
-                            .map(|k| GoldilocksField(*k as u64))
-                            .unwrap_or(GoldilocksField::ZERO)
-                    })
-                    .collect()
-            })
-            .collect())
     }
 
     /// returns a map from input POD name to (map from statement name to statement)
@@ -414,7 +362,6 @@ impl GPGInput {
     /// the new origin names as specified by inputs.origin_renaming_map
     /// and with new origin IDs which correspond to the lexicographic order of the new origin names
     fn remap_origin_ids_by_name(&self) -> Result<HashMap<String, HashMap<String, Statement>>> {
-        let new_origin_name_to_id_map = self.origin_name_to_new_id_map();
         // Iterate through all statements, leaving parent names intact
         // and replacing statement names with their new names
         // (according to `origin_renaming_map`) and replacing origin
@@ -424,24 +371,17 @@ impl GPGInput {
             .iter()
             .map(|(pod_name, pod)| {
                 let origin_remapper = Box::new(|origin_name: &str| {
-                    let new_origin_name = self
+                    let (new_origin_name, new_origin_id) = self
                         .origin_renaming_map
                         .get(&(pod_name.clone(), origin_name.to_string()))
                         .ok_or(anyhow!(
-                            "Couldn't find new origin name for origin {}.{}.",
+                            "Couldn't find new origin name and ID for origin {}.{}.",
                             pod_name,
                             origin_name
                         ))?;
-                    let new_origin_id =
-                        new_origin_name_to_id_map
-                            .get(new_origin_name)
-                            .ok_or(anyhow!(
-                                "Couldn't find ID for new origin {}.",
-                                new_origin_name
-                            ))?;
                     Ok((
                         new_origin_name.clone(),
-                        GoldilocksField::from_canonical_u64(*new_origin_id as u64),
+                        *new_origin_id
                     ))
                 });
                 Ok((

--- a/pod2/src/pod/mod.rs
+++ b/pod2/src/pod/mod.rs
@@ -361,6 +361,11 @@ impl GPGInput {
                         (pod.clone(), old_origin_name),
                         (pod.clone(), named_pods.get(&pod).unwrap().content_id()),
                     )
+                } else if old_origin_id == ORIGIN_ID_NONE {
+                    (
+                        (pod.clone(), old_origin_name.clone()),
+                        (ORIGIN_NAME_NONE.into(), old_origin_id),
+                    )
                 } else {
                     (
                         (pod.clone(), old_origin_name.clone()),

--- a/pod2/src/pod/origin.rs
+++ b/pod2/src/pod/origin.rs
@@ -2,18 +2,26 @@ use anyhow::Result;
 use plonky2::field::{goldilocks_field::GoldilocksField, types::Field};
 use serde::{Deserialize, Serialize};
 
-use super::gadget::GadgetID;
+use super::{gadget::GadgetID, ContentID};
+
+pub type OriginID = ContentID;
+
+pub const ORIGIN_ID_NONE: OriginID = [GoldilocksField::ZERO,GoldilocksField::ZERO, GoldilocksField::ZERO, GoldilocksField::ZERO];
+pub const ORIGIN_ID_SELF: OriginID = [GoldilocksField::ONE,GoldilocksField::ZERO, GoldilocksField::ZERO, GoldilocksField::ZERO];
+
+pub const ORIGIN_NAME_NONE: &'static str = "_NONE";
+pub const ORIGIN_NAME_SELF: &'static str = "_SELF ";
 
 // An Origin, which represents a reference to an ancestor POD.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Default)]
 pub struct Origin {
-    pub origin_id: GoldilocksField, // reserve 0 for NONE, 1 for SELF
+    pub origin_id: OriginID, // reserve 0 for NONE, 1 for SELF
     pub origin_name: String,
     pub gadget_id: GadgetID, // if origin_id is SELF, this is none; otherwise, it's the gadget_id
 }
 
 impl Origin {
-    pub fn new(origin_id: GoldilocksField, origin_name: String, gadget_id: GadgetID) -> Self {
+    pub fn new(origin_id: OriginID, origin_name: String, gadget_id: GadgetID) -> Self {
         Origin {
             origin_id,
             origin_name,
@@ -21,12 +29,12 @@ impl Origin {
         }
     }
     pub const NONE: Self = Origin {
-        origin_id: GoldilocksField::ZERO,
+        origin_id: ORIGIN_ID_NONE,
         origin_name: String::new(),
         gadget_id: GadgetID::NONE,
     };
     pub const SELF: Self = Origin {
-        origin_id: GoldilocksField(1),
+        origin_id: ORIGIN_ID_SELF,
         origin_name: String::new(),
         gadget_id: GadgetID::NONE,
     };
@@ -38,17 +46,16 @@ impl Origin {
         Self::new(Self::SELF.origin_id, origin_name, gadget_id)
     }
     pub fn is_self(&self) -> bool {
-        self.origin_id == GoldilocksField(1)
+        self.origin_id == ORIGIN_ID_SELF
     }
     /// Field representation as a vector of length 2.
     pub fn to_fields(&self) -> Vec<GoldilocksField> {
-        vec![
-            self.origin_id,
+        [self.origin_id.to_vec(),vec![
             GoldilocksField::from_canonical_u64(self.gadget_id as u64),
-        ]
+        ]].concat()
     }
     // Remap origin according to name-based rule.
-    pub fn remap(&self, f: &dyn Fn(&str) -> Result<(String, GoldilocksField)>) -> Result<Self> {
+    pub fn remap(&self, f: &dyn Fn(&str) -> Result<(String, OriginID)>) -> Result<Self> {
         let (new_origin_name, new_origin_id) = f(&self.origin_name)?;
         Ok(Self::new(new_origin_id, new_origin_name, self.gadget_id))
     }

--- a/pod2/src/pod/origin.rs
+++ b/pod2/src/pod/origin.rs
@@ -6,8 +6,18 @@ use super::{gadget::GadgetID, ContentID};
 
 pub type OriginID = ContentID;
 
-pub const ORIGIN_ID_NONE: OriginID = [GoldilocksField::ZERO,GoldilocksField::ZERO, GoldilocksField::ZERO, GoldilocksField::ZERO];
-pub const ORIGIN_ID_SELF: OriginID = [GoldilocksField::ONE,GoldilocksField::ZERO, GoldilocksField::ZERO, GoldilocksField::ZERO];
+pub const ORIGIN_ID_NONE: OriginID = [
+    GoldilocksField::ZERO,
+    GoldilocksField::ZERO,
+    GoldilocksField::ZERO,
+    GoldilocksField::ZERO,
+];
+pub const ORIGIN_ID_SELF: OriginID = [
+    GoldilocksField::ONE,
+    GoldilocksField::ZERO,
+    GoldilocksField::ZERO,
+    GoldilocksField::ZERO,
+];
 
 pub const ORIGIN_NAME_NONE: &'static str = "_NONE";
 pub const ORIGIN_NAME_SELF: &'static str = "_SELF ";
@@ -50,9 +60,11 @@ impl Origin {
     }
     /// Field representation as a vector of length 2.
     pub fn to_fields(&self) -> Vec<GoldilocksField> {
-        [self.origin_id.to_vec(),vec![
-            GoldilocksField::from_canonical_u64(self.gadget_id as u64),
-        ]].concat()
+        [
+            self.origin_id.to_vec(),
+            vec![GoldilocksField::from_canonical_u64(self.gadget_id as u64)],
+        ]
+        .concat()
     }
     // Remap origin according to name-based rule.
     pub fn remap(&self, f: &dyn Fn(&str) -> Result<(String, OriginID)>) -> Result<Self> {

--- a/pod2/src/pod/statement.rs
+++ b/pod2/src/pod/statement.rs
@@ -9,7 +9,7 @@ use std::{collections::HashMap, fmt, fmt::Debug};
 use super::{
     entry::Entry,
     gadget::GadgetID,
-    origin::Origin,
+    origin::{Origin, OriginID},
     util::hash_string_to_field,
     value::{HashableEntryValue, ScalarOrVec},
     POD,
@@ -34,7 +34,7 @@ impl AnchoredKey {
     }
     pub fn remap_origin(
         &self,
-        f: &dyn Fn(&str) -> Result<(String, GoldilocksField)>,
+        f: &dyn Fn(&str) -> Result<(String, OriginID)>,
     ) -> Result<Self> {
         let AnchoredKey(origin, key) = self;
         Ok(AnchoredKey(origin.remap(f)?, key.clone()))
@@ -226,7 +226,7 @@ impl Statement {
     }
     pub fn remap_origins(
         &self,
-        f: &dyn Fn(&str) -> Result<(String, GoldilocksField)>,
+        f: &dyn Fn(&str) -> Result<(String, OriginID)>,
     ) -> Result<Self> {
         match self {
             Self::None => Ok(Self::None),

--- a/pod2/src/pod/statement.rs
+++ b/pod2/src/pod/statement.rs
@@ -27,15 +27,13 @@ impl PartialEq for AnchoredKey {
 }
 
 impl AnchoredKey {
-    /// Field representation as a vector of length 3.
+    // TODO: Make string hashing more secure.
+    /// Field representation as a vector of length 6.
     pub fn to_fields(&self) -> Vec<GoldilocksField> {
         let AnchoredKey(origin, key) = self;
         [origin.to_fields(), vec![hash_string_to_field(key)]].concat()
     }
-    pub fn remap_origin(
-        &self,
-        f: &dyn Fn(&str) -> Result<(String, OriginID)>,
-    ) -> Result<Self> {
+    pub fn remap_origin(&self, f: &dyn Fn(&str) -> Result<(String, OriginID)>) -> Result<Self> {
         let AnchoredKey(origin, key) = self;
         Ok(AnchoredKey(origin.remap(f)?, key.clone()))
     }
@@ -153,7 +151,7 @@ impl Statement {
             Self::Lt(_, _) => Self::LT,
         }
     }
-    /// Field representation as a vector of length 11.
+    /// Field representation as a vector of length 20.
     /// Each statement is arranged as
     /// [code] ++ anchored_key1 ++ anchored_key2 ++ anchored_key3 ++ [value],
     /// where the leftmost keys are populated first and 0s are substituted in
@@ -162,9 +160,10 @@ impl Statement {
         [
             vec![self.code()],
             match self {
-                Self::None => vec![GoldilocksField::ZERO; 10],
+                Self::None => vec![GoldilocksField::ZERO; 19],
                 Self::ValueOf(anchkey, value) => [
                     anchkey.to_fields(),
+                    vec![GoldilocksField::ZERO; 6],
                     vec![GoldilocksField::ZERO; 6],
                     vec![value.hash_or_value()],
                 ]
@@ -172,31 +171,36 @@ impl Statement {
                 Self::Equal(anchkey1, anchkey2) => [
                     anchkey1.to_fields(),
                     anchkey2.to_fields(),
-                    vec![GoldilocksField::ZERO; 4],
+                    vec![GoldilocksField::ZERO; 6],
+                    vec![GoldilocksField::ZERO],
                 ]
                 .concat(),
                 Self::NotEqual(anchkey1, anchkey2) => [
                     anchkey1.to_fields(),
                     anchkey2.to_fields(),
-                    vec![GoldilocksField::ZERO; 4],
+                    vec![GoldilocksField::ZERO; 6],
+                    vec![GoldilocksField::ZERO],
                 ]
                 .concat(),
                 Self::Gt(anchkey1, anchkey2) => [
                     anchkey1.to_fields(),
                     anchkey2.to_fields(),
-                    vec![GoldilocksField::ZERO; 4],
+                    vec![GoldilocksField::ZERO; 6],
+                    vec![GoldilocksField::ZERO],
                 ]
                 .concat(),
                 Self::Lt(anchkey1, anchkey2) => [
                     anchkey1.to_fields(),
                     anchkey2.to_fields(),
-                    vec![GoldilocksField::ZERO; 4],
+                    vec![GoldilocksField::ZERO; 6],
+                    vec![GoldilocksField::ZERO],
                 ]
                 .concat(),
                 Self::Contains(anchkey1, anchkey2) => [
                     anchkey1.to_fields(),
                     anchkey2.to_fields(),
-                    vec![GoldilocksField::ZERO; 4],
+                    vec![GoldilocksField::ZERO; 6],
+                    vec![GoldilocksField::ZERO],
                 ]
                 .concat(),
                 Self::SumOf(anchkey1, anchkey2, anchkey3) => [
@@ -224,10 +228,7 @@ impl Statement {
         ]
         .concat()
     }
-    pub fn remap_origins(
-        &self,
-        f: &dyn Fn(&str) -> Result<(String, OriginID)>,
-    ) -> Result<Self> {
+    pub fn remap_origins(&self, f: &dyn Fn(&str) -> Result<(String, OriginID)>) -> Result<Self> {
         match self {
             Self::None => Ok(Self::None),
             Self::ValueOf(anchkey1, v) => Ok(Self::ValueOf(anchkey1.remap_origin(f)?, v.clone())),

--- a/pod2/src/signature/biguint.rs
+++ b/pod2/src/signature/biguint.rs
@@ -147,7 +147,8 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilderBiguint<F, D>
         result.push(self._true().target);
         for i in 0..n {
             let this_limb_cmp_result = self.is_equal(a.limbs[i].0, b.limbs[i].0);
-            let result_after_this_limb = self.mul(*result.last().unwrap(), this_limb_cmp_result.target);
+            let result_after_this_limb =
+                self.mul(*result.last().unwrap(), this_limb_cmp_result.target);
             result.push(result_after_this_limb);
         }
         BoolTarget::new_unsafe(*result.last().unwrap())
@@ -587,7 +588,7 @@ mod tests {
         data.verify(proof);
         ()
     }
-    
+
     #[test]
     fn test_is_equal_false_0() {
         const D: usize = 2;
@@ -612,7 +613,7 @@ mod tests {
         data.verify(proof);
         ()
     }
-    
+
     #[test]
     fn test_is_equal_false_1() {
         const D: usize = 2;

--- a/pod2/src/signature/eddsa.rs
+++ b/pod2/src/signature/eddsa.rs
@@ -40,7 +40,7 @@ pub struct EddsaPublicKeyTarget {
 }
 
 pub trait EddsaBuilder {
-    fn verify_eddsa<C: GenericConfig<2, F = GoldF>> (
+    fn verify_eddsa<C: GenericConfig<2, F = GoldF>>(
         &mut self,
         sig: &EddsaSignatureTarget,
         msg: &MessageHashTarget,
@@ -48,7 +48,7 @@ pub trait EddsaBuilder {
         hash: &PoseidonOutputTarget, // will not be needed in final version
     ) -> BoolTarget;
 
-    fn constrain_eddsa<C: GenericConfig<2, F = GoldF>> (
+    fn constrain_eddsa<C: GenericConfig<2, F = GoldF>>(
         &mut self,
         sig: &EddsaSignatureTarget,
         msg: &MessageHashTarget,
@@ -58,17 +58,17 @@ pub trait EddsaBuilder {
 }
 
 impl EddsaBuilder for CircuitBuilder<GoldF, 2> {
-    fn verify_eddsa<C: GenericConfig<2, F = GoldF>> (
+    fn verify_eddsa<C: GenericConfig<2, F = GoldF>>(
         &mut self,
         sig: &EddsaSignatureTarget,
         msg: &MessageHashTarget,
         pk: &EddsaPublicKeyTarget,
         hash: &PoseidonOutputTarget, // will not be needed in final version
-    ) -> BoolTarget {      
+    ) -> BoolTarget {
         self.verify_jubjub_point(&sig.r);
         self.verify_jubjub_point(&pk.a);
-//        HASH TO BE IMPLEMENTED: h should be Poseidon hash of sig.r, pk, msg
-//        let h: BigUintTarget = p_hash_to_implement(sig.r.x, sig.r.y, pk.x, pk.y, msg);
+        //        HASH TO BE IMPLEMENTED: h should be Poseidon hash of sig.r, pk, msg
+        //        let h: BigUintTarget = p_hash_to_implement(sig.r.x, sig.r.y, pk.x, pk.y, msg);
         let b8 = self.B8_jubjub_curve();
         let lhs: JubjubCurveTarget = self.mul_scalar(&b8, &sig.s);
         let eight = self.constant_biguint(&BigUint::new(vec![8]));
@@ -77,8 +77,8 @@ impl EddsaBuilder for CircuitBuilder<GoldF, 2> {
         let rhs = self.add_jubjub_curve(&sig.r, &hash_times_pk);
         self.is_equal_jubjub_curve(&lhs, &rhs)
     }
-    
-    fn constrain_eddsa<C: GenericConfig<2, F = GoldF>> (
+
+    fn constrain_eddsa<C: GenericConfig<2, F = GoldF>>(
         &mut self,
         sig: &EddsaSignatureTarget,
         msg: &MessageHashTarget,
@@ -89,7 +89,7 @@ impl EddsaBuilder for CircuitBuilder<GoldF, 2> {
         let true_target = self._true();
         self.connect(verification_output.target, true_target.target);
     }
-} 
+}
 
 #[cfg(test)]
 mod tests {
@@ -104,17 +104,16 @@ mod tests {
 
     use crate::signature::biguint::{BigUintTarget, CircuitBuilderBiguint};
     use crate::signature::eddsa::{
-        EddsaBuilder, 
-        EddsaPublicKeyTarget, 
-        EddsaSignatureTarget,
-        MessageHashTarget,
+        EddsaBuilder, EddsaPublicKeyTarget, EddsaSignatureTarget, MessageHashTarget,
         PoseidonOutputTarget,
     };
     use crate::signature::jubjubcurve::{CircuitBuilderJubjubCurve, JubjubCurveTarget};
     use crate::signature::jubjubfield::{CircuitBuilderJubjubField, JubjubFieldTarget};
 
     fn u64_to_u32(a: Vec<u64>) -> Vec<u32> {
-        a.into_iter().flat_map(|x| vec![x as u32, (x >> 32) as u32]).collect()
+        a.into_iter()
+            .flat_map(|x| vec![x as u32, (x >> 32) as u32])
+            .collect()
     }
 
     #[test]
@@ -137,12 +136,7 @@ mod tests {
             8589537196731344667,
             1113026192110903546,
         ]));
-        let msg_val = BigUint::new(u64_to_u32(vec![
-            14083847773837265618,
-            6692605942,
-            0,
-            0,
-        ]));
+        let msg_val = BigUint::new(u64_to_u32(vec![14083847773837265618, 6692605942, 0, 0]));
         let sig_r_x_val = BigUint::new(u64_to_u32(vec![
             3702867781738010923,
             14038445494684018940,
@@ -161,7 +155,8 @@ mod tests {
             14992547060379445581,
             133925459310743680,
         ]));
-        let hash_val = BigUint::new(u64_to_u32(vec![ // should be computed automatically later
+        let hash_val = BigUint::new(u64_to_u32(vec![
+            // should be computed automatically later
             2709608945152055826,
             8217237346447623338,
             9578917324956230137,
@@ -176,13 +171,19 @@ mod tests {
         let sig_s = JubjubFieldTarget(builder.constant_biguint(&sig_s_val));
         let hash = JubjubFieldTarget(builder.constant_biguint(&hash_val));
 
-        let pk = JubjubCurveTarget{ x: px, y: py };
-        let sig_r = JubjubCurveTarget{ x: sig_r_x, y: sig_r_y };
+        let pk = JubjubCurveTarget { x: px, y: py };
+        let sig_r = JubjubCurveTarget {
+            x: sig_r_x,
+            y: sig_r_y,
+        };
 
-        let msg = MessageHashTarget{ m: msg.0 };
-        let hash = PoseidonOutputTarget{ h: hash.0 };
-        let sig = EddsaSignatureTarget{ r: sig_r, s: sig_s.0 };
-        let pk = EddsaPublicKeyTarget{ a: pk };
+        let msg = MessageHashTarget { m: msg.0 };
+        let hash = PoseidonOutputTarget { h: hash.0 };
+        let sig = EddsaSignatureTarget {
+            r: sig_r,
+            s: sig_s.0,
+        };
+        let pk = EddsaPublicKeyTarget { a: pk };
 
         builder.constrain_eddsa::<C>(&sig, &msg, &pk, &hash);
 
@@ -190,7 +191,7 @@ mod tests {
         let proof = data.prove(pw).unwrap();
         data.verify(proof);
     }
-    
+
     #[test]
     fn test_verify_sig_to_false() {
         // this signature is incorrect, test should fail
@@ -212,12 +213,7 @@ mod tests {
             8589537196731344667,
             1113026192110903546,
         ]));
-        let msg_val = BigUint::new(u64_to_u32(vec![
-            14083847773837265618,
-            6692605942,
-            0,
-            0,
-        ]));
+        let msg_val = BigUint::new(u64_to_u32(vec![14083847773837265618, 6692605942, 0, 0]));
         let sig_r_x_val = BigUint::new(u64_to_u32(vec![
             3702867781738010923,
             14038445494684018940,
@@ -236,7 +232,8 @@ mod tests {
             14992547060379445581,
             133925459310743681, // this value was changed from the correct val
         ]));
-        let hash_val = BigUint::new(u64_to_u32(vec![ // should be computed automatically later
+        let hash_val = BigUint::new(u64_to_u32(vec![
+            // should be computed automatically later
             2709608945152055826,
             8217237346447623338,
             9578917324956230137,
@@ -251,13 +248,19 @@ mod tests {
         let sig_s = JubjubFieldTarget(builder.constant_biguint(&sig_s_val));
         let hash = JubjubFieldTarget(builder.constant_biguint(&hash_val));
 
-        let pk = JubjubCurveTarget{ x: px, y: py };
-        let sig_r = JubjubCurveTarget{ x: sig_r_x, y: sig_r_y };
+        let pk = JubjubCurveTarget { x: px, y: py };
+        let sig_r = JubjubCurveTarget {
+            x: sig_r_x,
+            y: sig_r_y,
+        };
 
-        let msg = MessageHashTarget{ m: msg.0 };
-        let hash = PoseidonOutputTarget{ h: hash.0 };
-        let sig = EddsaSignatureTarget{ r: sig_r, s: sig_s.0 };
-        let pk = EddsaPublicKeyTarget{ a: pk };
+        let msg = MessageHashTarget { m: msg.0 };
+        let hash = PoseidonOutputTarget { h: hash.0 };
+        let sig = EddsaSignatureTarget {
+            r: sig_r,
+            s: sig_s.0,
+        };
+        let pk = EddsaPublicKeyTarget { a: pk };
 
         let sig_result = builder.verify_eddsa::<C>(&sig, &msg, &pk, &hash);
         let false_target = builder._false();

--- a/pod2/src/signature/jubjubcurve.rs
+++ b/pod2/src/signature/jubjubcurve.rs
@@ -24,11 +24,8 @@ pub trait CircuitBuilderJubjubCurve {
 
     fn connect_jubjub_curve(&mut self, a: &JubjubCurveTarget, b: &JubjubCurveTarget);
 
-    fn is_equal_jubjub_curve(
-        &mut self, 
-        a: &JubjubCurveTarget, 
-        b: &JubjubCurveTarget
-    ) -> BoolTarget;
+    fn is_equal_jubjub_curve(&mut self, a: &JubjubCurveTarget, b: &JubjubCurveTarget)
+        -> BoolTarget;
 
     fn zero_jubjub_curve(&mut self) -> JubjubCurveTarget;
 
@@ -74,9 +71,9 @@ impl CircuitBuilderJubjubCurve for CircuitBuilder<GoldilocksField, 2> {
     }
 
     fn is_equal_jubjub_curve(
-        &mut self, 
-        a: &JubjubCurveTarget, 
-        b: &JubjubCurveTarget
+        &mut self,
+        a: &JubjubCurveTarget,
+        b: &JubjubCurveTarget,
     ) -> BoolTarget {
         let x_is_equal = self.is_equal_jubjubfield(&a.x, &b.x).target;
         let y_is_equal = self.is_equal_jubjubfield(&a.y, &b.y).target;
@@ -365,7 +362,11 @@ mod tests {
 
         let data = builder.build::<C>();
 
-        let proof: plonky2::plonk::proof::ProofWithPublicInputs<GoldilocksField, PoseidonGoldilocksConfig, 2> = data.prove(pw).unwrap();
+        let proof: plonky2::plonk::proof::ProofWithPublicInputs<
+            GoldilocksField,
+            PoseidonGoldilocksConfig,
+            2,
+        > = data.prove(pw).unwrap();
         data.verify(proof);
     }
 

--- a/pod2/src/signature/jubjubfield.rs
+++ b/pod2/src/signature/jubjubfield.rs
@@ -52,11 +52,7 @@ pub trait CircuitBuilderJubjubField {
 
     fn connect_jubjubfield(&mut self, a: &JubjubFieldTarget, b: &JubjubFieldTarget);
 
-    fn is_equal_jubjubfield(
-        &mut self, 
-        a: &JubjubFieldTarget, 
-        b: &JubjubFieldTarget
-    ) -> BoolTarget;
+    fn is_equal_jubjubfield(&mut self, a: &JubjubFieldTarget, b: &JubjubFieldTarget) -> BoolTarget;
 
     fn add_jubjubfield(
         &mut self,
@@ -130,11 +126,7 @@ impl CircuitBuilderJubjubField for CircuitBuilder<GoldilocksField, 2> {
         self.connect_biguint(&a.0, &b.0);
     }
 
-    fn is_equal_jubjubfield(
-        &mut self, 
-        a: &JubjubFieldTarget, 
-        b: &JubjubFieldTarget
-    ) -> BoolTarget {
+    fn is_equal_jubjubfield(&mut self, a: &JubjubFieldTarget, b: &JubjubFieldTarget) -> BoolTarget {
         self.is_equal_biguint(&a.0, &b.0)
     }
 


### PR DESCRIPTION
This PR replaces arbitrary origin IDs with content IDs with the exception of "_NONE" and "_SELF" origins which correspond to field elements 0 and 1 respectively. Note that content IDs are specified by 4 field elements (so that 0 and 1 are really [0,0,0,0] and [1,0,0,0] respectively), since that is the output length of the (Poseidon) hash function we're using. A subsequent PR will allow for key hashes and values of this type.