### PR TITLE
add basic signer client to simplify mass POD creation

### DIFF
--- a/go/pod/create.go
+++ b/go/pod/create.go
@@ -7,18 +7,56 @@ import (
 	"github.com/iden3/go-iden3-crypto/v2/babyjub"
 )
 
+type Signer struct {
+	privateKey babyjub.PrivateKey
+}
+
+func NewSigner(privateKeyHex string) (*Signer, error) {
+	privateKey, err := parsePrivateKey(privateKeyHex)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse private key: %w", err)
+	}
+
+	return &Signer{privateKey: privateKey}, nil
+}
+
+func (s *Signer) Sign(entries PodEntries) (*Pod, error) {
+	return signPod(s.privateKey, entries)
+}
+
 func CreatePod(privateKeyHex string, entries PodEntries) (*Pod, error) {
+	privateKey, err := parsePrivateKey(privateKeyHex)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse private key: %w", err)
+	}
+
+	return signPod(privateKey, entries)
+}
+
+func parsePrivateKey(privateKeyHex string) (babyjub.PrivateKey, error) {
 	var privateKey babyjub.PrivateKey
+
 	// Ensure privateKeyHex is in hexadecimal format
 	if len(privateKeyHex) != 64 {
 		privateKeyBytes, err := noPadB64.DecodeString(privateKeyHex)
 		if err != nil {
-			return nil, fmt.Errorf("private key must be 32-byte hex or base64 string: %w", err)
+			return privateKey, fmt.Errorf("private key must be 32-byte hex or base64 string: %w", err)
 		}
 		privateKeyHex = hex.EncodeToString(privateKeyBytes)
 	}
-	hex.Decode(privateKey[:], []byte(privateKeyHex))
-	return signPod(privateKey, entries)
+
+	decodedHex, err := hex.DecodeString(privateKeyHex)
+	if err != nil {
+		return privateKey, fmt.Errorf("malformed private key: %w", err)
+	}
+
+	if len(decodedHex) != 32 {
+		return privateKey, fmt.Errorf("private key must be 32-byte")
+	}
+
+	privateKey = babyjub.PrivateKey(decodedHex)
+
+	return privateKey, nil
 }
 
 func signPod(privateKey babyjub.PrivateKey, entries PodEntries) (*Pod, error) {


### PR DESCRIPTION
Mostly to avoid parsing and decoding the private key on every POD signing, also add more checks to the private key parsing.

You would use it like this on your app startup

```go
signer, err := pod.NewSigner(os.Getenv("SUPER_SECRET_KEY")")
if err != nil {
  log.Fatalf("bad config: %v", err)
}
```
then you can pass the signer around your app and do

```go
signer.Sign(entriesFoo)
```

let me know if you want to rename things 👍 